### PR TITLE
reorder load event batch

### DIFF
--- a/api.md
+++ b/api.md
@@ -406,6 +406,67 @@ curl "$GOTRACE_API/v1/loads/$LOAD_ID/events" \
 </details>
 
 
+#### Event Types
+
+##### `created`
+
+Automatically generated when a new load is posted. 
+May include the optional fields `source_load_ids` and `fields`.
+
+##### `gps-start`
+
+Initiates a tracking session. User must 'own' the load.
+
+##### `gps-track`
+
+Logs a geo point. Must follow `gps-start` or `gps-track`.
+
+##### `gps-stop`
+
+Ends a tracking session. Must follow `gps-track` or `gps-start`.
+
+##### `accepted`
+
+Transfers a load to a new user.
+
+##### `added`
+
+Adds a load to a 'parent' container load. Requires `parent_id` field.
+
+##### `removed`
+
+Removes a load from the current 'parent' container load.
+
+##### `updated`
+
+Updates load fields. Requires `fields` field, which is treated as a set of fields to PATCH.
+Mutable fields include `name` (string) and `data` (object). Rather than setting `data` as a whole (which will overwrite),
+one or more individual fields can be updated using dot notation (`data.*`).  
+
+<details>   
+<summary>Example data</summary>
+
+```json
+{
+  "name": "new name",
+  "data": {"custom": "field"}
+}
+```
+</details>
+
+<details>
+<summary>Example data.*</summary>
+
+```json
+{
+  "name": "new name",
+  "data.custom": "field",
+  "data.custom2": "value"
+}
+```
+</details>
+
+
 ### POST Load Events(batch)
 
 
@@ -527,67 +588,6 @@ You could use either of the following parameters (or both):
       "tx_hash": "0x5c23471b8b6748acadbbf9367f"
     }
   ]
-}
-```
-</details>
-
-
-#### Event Types
-
-##### `created`
-
-Automatically generated when a new load is posted. 
-May include the optional fields `source_load_ids` and `fields`.
-
-##### `gps-start`
-
-Initiates a tracking session. User must 'own' the load.
-
-##### `gps-track`
-
-Logs a geo point. Must follow `gps-start` or `gps-track`.
-
-##### `gps-stop`
-
-Ends a tracking session. Must follow `gps-track` or `gps-start`.
-
-##### `accepted`
-
-Transfers a load to a new user.
-
-##### `added`
-
-Adds a load to a 'parent' container load. Requires `parent_id` field.
-
-##### `removed`
-
-Removes a load from the current 'parent' container load.
-
-##### `updated`
-
-Updates load fields. Requires `fields` field, which is treated as a set of fields to PATCH.
-Mutable fields include `name` (string) and `data` (object). Rather than setting `data` as a whole (which will overwrite),
-one or more individual fields can be updated using dot notation (`data.*`).  
-
-<details>   
-<summary>Example data</summary>
-
-```json
-{
-  "name": "new name",
-  "data": {"custom": "field"}
-}
-```
-</details>
-
-<details>
-<summary>Example data.*</summary>
-
-```json
-{
-  "name": "new name",
-  "data.custom": "field",
-  "data.custom2": "value"
 }
 ```
 </details>


### PR DESCRIPTION
The diff is a mess, but this is just moving the Load event batch docs to be after the load event docs instead of in the middle (just flipped with event types).
I already removed some of the extra fields from the examples.